### PR TITLE
Split single statements by resource or action rather than all one or …

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -179,6 +179,48 @@ def test_policy_combine_big_resource():
         version="2012-10-17",
         statements=[Statement({"Action": ["spam"], "NotResource": "b" * b_len})],
     )
+
+
+def test_policy_combine_big_action_and_resource():
+    """Combining two big policies does as expected."""
+
+    a_len = int(policy.MAX_MANAGED_POLICY_SIZE * 0.4)
+    b_len = int(policy.MAX_MANAGED_POLICY_SIZE * 0.7)
+    c_len = int(policy.MAX_MANAGED_POLICY_SIZE * 0.4)
+
+    old_statements = [
+        Statement({"Action": [char * length], "NotResource": "spam"})
+        for char, length in [("a", a_len), ("b", b_len), ("c", c_len)]
+    ]
+    old_statements.extend([
+        Statement({"Action": "spam", "NotResource": [char * length]})
+        for char, length in [("a", a_len), ("b", b_len), ("c", c_len)]
+    ])
+
+    policies = policy.combine([Policy(statements=old_statements)])
+
+    assert len(policies) == 4
+
+    assert policies[0] == Policy(
+        version="2012-10-17",
+        statements=[Statement({"Action": ["spam"], "NotResource": ["a" * a_len, "c" * c_len]})],
+    )
+
+    assert policies[1] == Policy(
+        version="2012-10-17",
+        statements=[Statement({"Action": ["spam"], "NotResource": "b" * b_len})],
+    )
+
+    assert policies[2] == Policy(
+        version="2012-10-17",
+        statements=[Statement({"Action": ["a" * a_len, "c" * c_len], "NotResource": "spam"})],
+    )
+
+    assert policies[3] == Policy(
+        version="2012-10-17",
+        statements=[Statement({"Action": "b" * b_len, "NotResource": "spam"})],
+    )
+
 #
 
 def test_grouped_actions():

--- a/wonk/policy.py
+++ b/wonk/policy.py
@@ -123,11 +123,19 @@ def combine(policies: List[Policy]) -> List[Policy]:
         for statement in new_policy.statements:
             # If we have a single action and we end up splitting it, we need to split by resource instead
             statement_split = list(statement.split(max_statement_size))
-            if len(statement.action_value) == 1 and len(statement_split) > 1:
-                split_by_resource = True
-                break
-            for statement_dict in statement_split:
-                split_statements.append(smallest_json(statement_dict))
+            if (
+                    (len(statement.action_value) == 1 and len(statement_split) > 1)
+                    or (
+                        any(len(str(s)) + minimum_possible_policy_size > MAX_MANAGED_POLICY_SIZE
+                            for s in statement_split)
+                    )
+            ):
+                for statement_dict in statement.split_resource(max_statement_size):
+                    split_statements.append(smallest_json(statement_dict))
+
+            else:
+                for statement_dict in statement_split:
+                    split_statements.append(smallest_json(statement_dict))
 
         for statement in split_statements:
             str_statement = str(statement)


### PR DESCRIPTION
…all the other